### PR TITLE
Fix Donut dataset handling

### DIFF
--- a/donut/predict_donut.py
+++ b/donut/predict_donut.py
@@ -21,9 +21,9 @@ def main(model_dir: str, img_path: str) -> None:
         max_length=512,
         num_beams=5,
         early_stopping=True,
+        use_cache=False,
     )
     pred = processor.batch_decode(generated_ids, skip_special_tokens=True)[0]
-
     try:
         result = json.loads(pred)
     except json.JSONDecodeError:

--- a/donut/train_donut.py
+++ b/donut/train_donut.py
@@ -78,7 +78,6 @@ def main() -> None:
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
-    global processor
     processor = DonutProcessor.from_pretrained(model_name)
     processor.tokenizer.model_max_length = 128
 

--- a/donut/train_donut.py
+++ b/donut/train_donut.py
@@ -16,6 +16,9 @@ from transformers import (
     Seq2SeqTrainer,
 )
 
+TASK_PROMPT = "<s_serialize>"
+processor: DonutProcessor | None = None
+
 
 class DonutDataset(Dataset):
     """Simple dataset reading images and JSON ground truth."""
@@ -36,7 +39,7 @@ class DonutDataset(Dataset):
         key = img_path.stem
         with open(self.gts[key], encoding="utf-8") as f:
             gt = json.load(f)
-        target_str = json.dumps(gt, ensure_ascii=False)
+        target_str = TASK_PROMPT + json.dumps(gt, ensure_ascii=False)
         image = Image.open(img_path).convert("RGB")
         data = self.processor(
             images=image,
@@ -55,6 +58,7 @@ def donut_collate_fn(batch):
 
     pixel_values = torch.stack([item["pixel_values"] for item in batch])
     labels = torch.stack([item["labels"] for item in batch])
+    labels[labels == processor.tokenizer.pad_token_id] = -100
     return {
         "pixel_values": pixel_values,
         "labels": labels,
@@ -74,6 +78,7 @@ def main() -> None:
 
     device = "cuda" if torch.cuda.is_available() else "cpu"
 
+    global processor
     processor = DonutProcessor.from_pretrained(model_name)
     processor.tokenizer.model_max_length = 128
 


### PR DESCRIPTION
## Summary
- add `<s_serialize>` prompt and mask padding when collating
- parse prediction output correctly and disable cache when generating

## Testing
- `python -m py_compile donut/train_donut.py donut/predict_donut.py`

------
https://chatgpt.com/codex/tasks/task_e_68698c294cc08328a6c07439b33c1f02